### PR TITLE
Immediately set text when set date.

### DIFF
--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerEditText.java
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerEditText.java
@@ -143,8 +143,13 @@ public final class DatePickerEditText extends AppCompatEditText implements OnFoc
         return date;
     }
 
-    public DatePickerEditText setDate(@NonNull Calendar date) {
-        this.date = date;
+    public DatePickerEditText setDate(@NonNull Calendar calendar) {
+        if (textDateFormat != null) {
+            setText(textDateFormat.format(calendar.getTime()));
+        } else {
+            setText(DateUtils.toDate(calendar.getTime(), dateFormat));
+        }
+        date = calendar;
         return this;
     }
 


### PR DESCRIPTION
The following code is also possible, however a little bit troublesome...
```
            Calendar calendar = Calendar.getInstance();
            datePickerEditText.onDateSet(
                    null,
                    calendar.get(Calendar.YEAR),
                    calendar.get(Calendar.MONTH),
                    calendar.get(Calendar.DAY_OF_MONTH));
```
