### PR TITLE
I modified some functionalities in this library and update example sa…

### DIFF
--- a/app/src/main/java/io/blackbox_vision/sample/MainActivity.java
+++ b/app/src/main/java/io/blackbox_vision/sample/MainActivity.java
@@ -31,20 +31,20 @@ public final class MainActivity extends AppCompatActivity {
         datePickerInputEditText = (DatePickerInputEditText) findViewById(R.id.datePickerInputEditText);
         timePickerInputEditText = (TimePickerInputEditText) findViewById(R.id.timePickerInputEditText);
 
-        datePickerEditText.setManager(getSupportFragmentManager());
+        /*datePickerEditText.setManager(getSupportFragmentManager());
         timePickerEditText.setManager(getSupportFragmentManager());
 
         datePickerInputEditText.setManager(getSupportFragmentManager());
-        timePickerInputEditText.setManager(getSupportFragmentManager());
+        timePickerInputEditText.setManager(getSupportFragmentManager());*/
 
         // Set the date formatter with the given formatting style from device setting.
-        datePickerEditText.setDateFormat(DateFormat.getLongDateFormat(getApplicationContext()));
+//        datePickerEditText.setDateFormat(DateFormat.getLongDateFormat(getApplicationContext()));
         timePickerEditText.setTimeFormat(DateFormat.getTimeFormat(getApplicationContext()));
 
         datePickerInputEditText.setDateFormat(DateFormat.getMediumDateFormat(getApplicationContext()));
         timePickerInputEditText.setTimeFormat(DateFormat.getTimeFormat(getApplicationContext()));
 
-        datePickerEditText.setDate(Calendar.getInstance());
+//        datePickerEditText.setDate(Calendar.getInstance());
         datePickerInputEditText.setDate(Calendar.getInstance());
 
         timePickerEditText.setTime(Calendar.getInstance());

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/activity_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:orientation="vertical"
     android:focusable="false"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context="io.blackbox_vision.sample.MainActivity">
 
     <io.blackbox_vision.datetimepickeredittext.view.DatePickerEditText
@@ -18,14 +18,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:hint="@string/select_date"/>
+        android:hint="@string/select_date"
+        app:maxDate="CR_DATE" />
 
     <io.blackbox_vision.datetimepickeredittext.view.TimePickerEditText
         android:id="@+id/timePickerEditText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:hint="@string/select_time"/>
+        android:hint="@string/select_time" />
 
     <android.support.design.widget.TextInputLayout
         android:id="@+id/dateTextInputLayout"
@@ -38,9 +39,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/select_date"
-            app:minDate="01/01/1981"
+            app:dateFormat="yyyy/MM/dd"
             app:maxDate="01/01/2050"
-            app:dateFormat="yyyy/MM/dd"/>
+            app:minDate="01/01/1981" />
 
     </android.support.design.widget.TextInputLayout>
 
@@ -54,8 +55,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/select_time"
-            app:timeFormat="kk:mm"
-            app:is24HourView="true"/>
+            app:is24HourView="true"
+            app:timeFormat="kk:mm" />
 
     </android.support.design.widget.TextInputLayout>
 

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/fragment/DatePickerFragment.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/fragment/DatePickerFragment.kt
@@ -30,7 +30,9 @@ class DatePickerFragment : DialogFragment() {
         set
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val year: Int; val month: Int; val day: Int
+        val year: Int;
+        val month: Int;
+        val day: Int
 
         if (null != date) {
             year = date!!.get(Calendar.YEAR)
@@ -52,8 +54,11 @@ class DatePickerFragment : DialogFragment() {
             datePickerDialog = DatePickerDialog(activity, onDateSetListener, year, month, day)
         }
 
-        val minDateStr = if (null != minDate) minDate else DEFAULT_MIN_DATE
-        val maxDateStr = if (null != maxDate) maxDate else DEFAULT_MAX_DATE
+//        val minDateStr = if (null != minDate) minDate else DEFAULT_MIN_DATE
+//        val maxDateStr = if (null != maxDate) maxDate else DEFAULT_MAX_DATE
+
+        val minDateStr = if (null != minDate) DateUtils.gettingDate(minDate!!) else DEFAULT_MIN_DATE
+        val maxDateStr = if (null != maxDate) DateUtils.gettingDate(maxDate!!) else DEFAULT_MAX_DATE
 
         val min = DateUtils.parse(minDateStr, DEFAULT_TEMPLATE)!!.time
         val max = DateUtils.parse(maxDateStr, DEFAULT_TEMPLATE)!!.time

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/utils/DateUtils.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/utils/DateUtils.kt
@@ -40,4 +40,12 @@ object DateUtils {
 
         return date
     }
+
+    private fun currentDT(): String {
+        return SimpleDateFormat(DATE_TEMPLATE).format(System.currentTimeMillis())
+    }
+
+    fun gettingDate(selDate: String): String {
+        return selDate?.takeIf { !it.toUpperCase().equals("CR_DATE") } ?: currentDT()
+    }
 }

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/utils/DateUtils.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/internal/utils/DateUtils.kt
@@ -41,11 +41,11 @@ object DateUtils {
         return date
     }
 
-    private fun currentDT(): String {
+    private fun getCurrentDateTime(): String {
         return SimpleDateFormat(DATE_TEMPLATE).format(System.currentTimeMillis())
     }
 
-    fun gettingDate(selDate: String): String {
-        return selDate?.takeIf { !it.toUpperCase().equals("CR_DATE") } ?: currentDT()
+    fun gettingDate(strDate: String): String {
+        return strDate?.takeIf { !it.toUpperCase().equals("CR_DATE") } ?: getCurrentDateTime()
     }
 }

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerEditText.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerEditText.kt
@@ -20,6 +20,7 @@ import io.blackbox_vision.datetimepickeredittext.internal.utils.DateUtils
 import android.view.View.OnFocusChangeListener
 import android.view.View.OnClickListener
 import android.app.DatePickerDialog.OnDateSetListener
+import android.support.v7.app.AppCompatActivity
 
 
 class DatePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickListener, OnDateSetListener {
@@ -57,6 +58,9 @@ class DatePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickList
         inputType = InputType.TYPE_NULL
         onFocusChangeListener = this
         setOnClickListener(this)
+
+        /*Set fragment manager*/
+        manager = (context as AppCompatActivity).supportFragmentManager
     }
 
     private fun handleAttributes(attributeSet: AttributeSet) {
@@ -126,10 +130,10 @@ class DatePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickList
         return manager
     }
 
-    fun setManager(manager: FragmentManager): DatePickerEditText {
+    /*fun setManager(manager: FragmentManager): DatePickerEditText {
         this.manager = manager
         return this
-    }
+    }*/
 
     fun getDate(): Calendar? {
         return date

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerInputEditText.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/DatePickerInputEditText.kt
@@ -20,6 +20,7 @@ import io.blackbox_vision.datetimepickeredittext.internal.utils.DateUtils
 import android.view.View.OnFocusChangeListener
 import android.view.View.OnClickListener
 import android.app.DatePickerDialog.OnDateSetListener
+import android.support.v7.app.AppCompatActivity
 
 
 class DatePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClickListener, OnDateSetListener {
@@ -57,6 +58,9 @@ class DatePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClic
         inputType = InputType.TYPE_NULL
         onFocusChangeListener = this
         setOnClickListener(this)
+
+        /*Set fragment manager*/
+        manager = (context as AppCompatActivity).supportFragmentManager
     }
 
     private fun handleAttributes(attributeSet: AttributeSet) {
@@ -125,10 +129,10 @@ class DatePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClic
         return manager
     }
 
-    fun setManager(manager: FragmentManager): DatePickerInputEditText {
+/*    fun setManager(manager: FragmentManager): DatePickerInputEditText {
         this.manager = manager
         return this
-    }
+    }*/
 
     fun getDate(): Calendar? {
         return date

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/TimePickerEditText.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/TimePickerEditText.kt
@@ -20,6 +20,7 @@ import io.blackbox_vision.datetimepickeredittext.internal.utils.DateUtils
 import android.view.View.OnFocusChangeListener
 import android.view.View.OnClickListener
 import android.app.TimePickerDialog.OnTimeSetListener
+import android.support.v7.app.AppCompatActivity
 
 
 class TimePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickListener, OnTimeSetListener {
@@ -58,6 +59,9 @@ class TimePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickList
         inputType = InputType.TYPE_NULL
         onFocusChangeListener = this
         setOnClickListener(this)
+
+        /*Set fragment manager*/
+        manager = (context as AppCompatActivity).supportFragmentManager
     }
 
     private fun handleAttributes(attributeSet: AttributeSet) {
@@ -121,10 +125,10 @@ class TimePickerEditText : AppCompatEditText, OnFocusChangeListener, OnClickList
         return manager
     }
 
-    fun setManager(manager: FragmentManager): TimePickerEditText {
+    /*fun setManager(manager: FragmentManager): TimePickerEditText {
         this.manager = manager
         return this
-    }
+    }*/
 
     fun getTime(): Calendar? {
         return time

--- a/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/TimePickerInputEditText.kt
+++ b/datetimepickeredittext/src/main/java/io/blackbox_vision/datetimepickeredittext/view/TimePickerInputEditText.kt
@@ -20,6 +20,7 @@ import io.blackbox_vision.datetimepickeredittext.internal.utils.DateUtils
 import android.view.View.OnFocusChangeListener
 import android.view.View.OnClickListener
 import android.app.TimePickerDialog.OnTimeSetListener
+import android.support.v7.app.AppCompatActivity
 
 
 class TimePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClickListener, OnTimeSetListener {
@@ -58,6 +59,9 @@ class TimePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClic
         inputType = InputType.TYPE_NULL
         onFocusChangeListener = this
         setOnClickListener(this)
+
+        /*Set fragment manager*/
+        manager = (context as AppCompatActivity).supportFragmentManager
     }
 
     private fun handleAttributes(attributeSet: AttributeSet) {
@@ -121,10 +125,10 @@ class TimePickerInputEditText : TextInputEditText, OnFocusChangeListener, OnClic
         return manager
     }
 
-    fun setManager(manager: FragmentManager): TimePickerInputEditText {
+    /*fun setManager(manager: FragmentManager): TimePickerInputEditText {
         this.manager = manager
         return this
-    }
+    }*/
 
     fun getTime(): Calendar? {
         return time


### PR DESCRIPTION
I modified some functionalities in this library and update example sampleapp.

Firstly, now we don't need to setManager for date and time picker means we don't need these lines: 
' datePickerEditText.setManager(getSupportFragmentManager())  '
' timePickerEditText.setManager(getSupportFragmentManager()); '

Secondly, I added one feature that's if someone want to set the current date as min and max date then it can directly set through XML like: ' app:maxDate="CR_DATE" ' use the keyword '**CR_DATE**' and your work done.